### PR TITLE
force version name to be non-protected

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ If you want to update README.md file, run that script while being in 'hooks' fol
 | subnets | A list of VPC subnet into which the compute resource are launced | list | n/a | yes |
 | tags | Key-value pair tags to be applied to resource that are launched in the compute environment | string | `""` | no |
 | type | The type of the compute environment. Valid items are MANAGED or UNMANAGED | string | n/a | yes |
-| version | The version number of the template. Default: The default version of the launch template | string | `""` | no |
+| template_version | The version number of the template. Default: The default version of the launch template | string | `""` | no |
 
 ## Outputs
 

--- a/variables.tf
+++ b/variables.tf
@@ -119,7 +119,7 @@ variable "launch_template_name" {
   default     = ""
 }
 
-variable "version" {
+variable "template_version" {
   type        = "string"
   description = "The version number of the template. Default: The default version of the launch template"
   default     = ""


### PR DESCRIPTION
## Why? 
`version` is a protected variable. so hacking the name for now, since we don't use template version locally anyway.  